### PR TITLE
Load "qualification" dependencies

### DIFF
--- a/.github/workflows/qualification-report-dispatch.yaml
+++ b/.github/workflows/qualification-report-dispatch.yaml
@@ -25,7 +25,7 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck
-          needs: check
+          needs: check, qualification
 
       - name: build vignette
         run: |

--- a/.github/workflows/qualification-tests-dev.yaml
+++ b/.github/workflows/qualification-tests-dev.yaml
@@ -1,6 +1,8 @@
 on:
   pull_request:
     branches: dev
+  repository_dispatch:
+    types: [qualification-test]
   workflow_dispatch:
 
 name: qualification-tests-dev
@@ -35,6 +37,7 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck, any::devtools, any::here, local::.
+          needs: check, qualification
 
       - name: run qualification tests
         run: source(here::here("tests", "testqualification", "test_qualification.R"))

--- a/tests/testthat/test-RunWorkflow.R
+++ b/tests/testthat/test-RunWorkflow.R
@@ -7,7 +7,9 @@ library(purrr)
 library(cli)
 library(glue)
 
-wf_mapping <- MakeWorkflowList(strPath = "workflow/1_mappings", strPackage = "gsm.mapping")
+wf_mapping <- MakeWorkflowList(strPath = "workflow/1_mappings",
+                               strNames = c("AE", "SUBJ", "PD", "LB", "STUDCOMP", "SDRGCOMP", "DATACHG", "DATAENT", "QUERY", "COUNTRY", "SITE", "STUDY", "ENROLL"),
+                               strPackage = "gsm.mapping")
 workflows <- MakeWorkflowList(strNames = paste0("kri", sprintf("%04d", 1:2)), strPackage = "gsm.kri")
 
 # Don't run things we don't use.


### PR DESCRIPTION
Update dispatched GHAs to require `qualification` when run

- Closes #9 