### PR TITLE
Install gsm.qc as part of setup-r-dependencies step

### DIFF
--- a/.github/workflows/qualification-report.yaml
+++ b/.github/workflows/qualification-report.yaml
@@ -27,13 +27,11 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
+          extra-packages: local::., any::rcmdcheck
           needs: check
 
       - name: build vignette
         run: |
-          install.packages("devtools")
-          devtools::install(dependencies = T)
           tools::buildVignette("./vignettes/Qualification.Rmd")
         shell: Rscript {0}
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,4 +50,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3


### PR DESCRIPTION
## Overview
Updated the workflow file to get rid of an extra installation step.

## Test Notes/Sample Code
We can't really know if this worked until we trigger the workflow.

## Connected Issues
<!--- Links to issues, using "Closes #NNN" if the issue is closed via PR --->

- Hypothetically closes #40. Everything worked for me locally, but this is an installation issue, so we'll need to see it in context to make sure it works as expected.

