### PR TITLE
More workflow protection

### DIFF
--- a/.github/workflows/qualification-report-dispatch.yaml
+++ b/.github/workflows/qualification-report-dispatch.yaml
@@ -27,18 +27,22 @@ jobs:
           extra-packages: local::., any::rcmdcheck, any::rmarkdown, any::pak
           needs: check, qualification
 
-      - name: build vignette
+      - name: install target repo
         env:
           repo_name: ${{ github.event.client_payload.repository }}
           branch: ${{ github.event.client_payload.head_ref }}
         run: |
-          repo_slug <- Sys.getenv("repo_name")
-          repo_name_short <- gsub("Gilead-BioStats/", "", repo_slug)
           repo_branch <- Sys.getenv("branch", unset = "main")
           if (!isTRUE(grepl("[A-Za-z]", repo_branch))) {
             repo_branch = "main"
           }
-          pak::pak(paste0(repo_slug, "@", repo_branch))
+          pak::pak(paste0(Sys.getenv("repo_name"), "@", repo_branch))
+
+      - name: build vignette
+        env:
+          repo_name: ${{ github.event.client_payload.repository }}
+        run: |
+          repo_name_short <- gsub("Gilead-BioStats/", "", Sys.getenv("repo_name"))
           rmarkdown::render("./vignettes/Qualification.Rmd", output_dir = getwd(), params = list(repo = repo_name_short))
         shell: Rscript {0}
 


### PR DESCRIPTION
Protect against "" (or " ", etc) in the `repo_branch` variable. I also split the "install target repo" piece off from "build vignette".